### PR TITLE
Bug fix: 플랫폼 간 SLEEP 매크로 시간 단위 차이 및 중복 정의 에러 수정

### DIFF
--- a/main.c
+++ b/main.c
@@ -14,10 +14,12 @@
 #include "playerinfo.h"
 
 // sleep 함수를 호출하는 매크로 정의
+#ifndef SLEEP
 #ifdef _WIN32
-#define SLEEP(x) Sleep(x) // 윈도우 환경에서는 Sleep 함수 사용 
+#define SLEEP(x) Sleep(1000 * (x)) // 윈도우 환경에서는 Sleep 함수 사용, 밀리초 단위
 #else
-#define SLEEP(x) sleep(x) // 유닉스 계열 운영체제에서는 sleep 함수 사용 
+#define SLEEP(x) sleep(x) // 유닉스 계열 운영체제에서는 sleep 함수 사용, 초 단위
+#endif
 #endif
 
 

--- a/main.c
+++ b/main.c
@@ -8,6 +8,7 @@
 #include <windows.h> // 윈도우 환경에서 Sleep 함수를 사용하기 위한 헤더 파일
 #else
 #include <unistd.h> // 유닉스 계열 운영체제에서 sleep 함수를 사용하기 위한 헤더 파일
+#include <sys/time.h> //유닉스 계열 운영체제에서 gettimeofday 함수를 사용하기 위한 헤더 파일
 #endif
 
 #include "playerinfo.h"
@@ -441,9 +442,17 @@ int monsterEncounter(int monster_lev) //입력한 난이도 받기
 {
     int monsterCount = 0;
     // 시간을 더 세분화하여 시드 값을 만듦
-    SYSTEMTIME st;
-    GetSystemTime(&st);
-    srand((unsigned int)(st.wMilliseconds));
+ 
+    #ifdef _WIN32
+        SYSTEMTIME st;
+        GetSystemTime(&st);
+        srand((unsigned int)(st.wMilliseconds));
+    #else
+        struct timeval time;
+        gettimeofday(&time, NULL);
+        srand((time.tv_sec * 1000) + (time.tv_usec / 1000));
+    #endif
+
     switch (monster_lev) {
     case 1:
         monsterCount = (rand() % 2);


### PR DESCRIPTION
1. 시간 단위 차이 해결
Windows에서는 Sleep 함수가 밀리초 단위로 시간을 지연시키고, 유닉스 계열 운영체제에서는 sleep 함수가 초 단위로 시간을 지연. 이를 통일하기 위해 SLEEP 매크로를 정의할 때, Windows에서는 Sleep(1000 * (x))를 사용하여 초 단위를 밀리초 단위로 변환.

2. 매크로 재정의 방지
#ifndef SLEEP를 통해 SLEEP 매크로가 이미 정의되지 않은 경우에만 다음 코드를 컴파일하도록 수정. 이는 매크로가 여러 번 정의되는 것을 방지. 