### PR TITLE
Clean: choosePath()함수에서 경로 결정 시 새로 만든 getIntInput()함수삭제

### DIFF
--- a/dungeon.c
+++ b/dungeon.c
@@ -25,20 +25,7 @@ void choosePath()
         printf("2. Go left\n");
         printf("3. Go right\n");
         printf("Please enter choiche 1-3.\n");
-        // 사용자로부터 숫자 입력 받기
-        int choice = getIntInput();
-
-        // 선택이 올바른지 확인
-        if (choice >= 1 && choice <= 3)
-        {
-            path = choice;
-            break; // 올바른 입력이면 루프 종료
-        }
-        else
-        {
-            printf("Invalid Value: choose path again.\n");
-        }
-        // 종료
+  
         printf("If you want to exit the game, type 'f' and press enter.\n");
         fgets(str, STR_SIZE, stdin);
 

--- a/tools.c
+++ b/tools.c
@@ -74,39 +74,3 @@ void title(const char* title)
 }
 
 
-int getIntInput() 
-{
-    char input[STR_SIZE];
-    int value;
-
-    while (1) 
-    {
-        fgets(input, sizeof(input), stdin);
-        input[strcspn(input, "\n")] = '\0'; 
-
-        // 문자열이 숫자로 변환 가능한지 확인
-        if (isNumeric(input)) 
-        {
-            value = atoi(input);
-            break;
-        } 
-        else 
-        {
-            printf("Invalid input. Please enter a valid number: ");
-        }
-    }
-
-    return value;
-}
-
-int isNumeric(const char *str) 
-{
-    while (*str)
-    {
-        if (*str < '0' || *str > '9')
-            return 0;
-        str++;
-    }
-    return 1;
-}
-

--- a/tools.h
+++ b/tools.h
@@ -11,9 +11,5 @@ void checkForExit(const char* check);
 
 void title(const char* title);
 
-int getIntInput();
-
-int isNumeric(const char *str);
-
 
 #endif // TOOLS_H


### PR DESCRIPTION
choosePath()함수에서 경로 결정 시 새로 만든 getIntInput()함수가 기존함수와 기능이 중복되고, 다른 int에 대한 Input이 없다고 판단하여 삭제하였습니다.